### PR TITLE
Fixes to https://github.com/lord-server/lord/issues/1657 , https://github.com/lord-server/lord/issues/2380 , https://github.com/lord-server/lord/issues/2383

### DIFF
--- a/painting.lua
+++ b/painting.lua
@@ -511,7 +511,6 @@ core.register_node("painting:easel", {
 			ent.res = data.res
 			ent.version = data.version
 			obj:set_properties{textures = { painting.to_imagestring(ent.grid, ent.res) }}
-			-- player:get_inventory():remove_item("main", wield_item:take_item())
 			wield_item:take_item()
 			player:set_wielded_item(wield_item)
 		else
@@ -520,7 +519,6 @@ core.register_node("painting:easel", {
 			ent.res = def._painting_canvas_resolution
 			ent.version = current_version
 			if not core.is_creative_enabled(player:get_player_name()) then
-				-- player:get_inventory():remove_item("main", wield_item:take_item())
 				wield_item:take_item()
 				player:set_wielded_item(wield_item)
 			end
@@ -528,7 +526,6 @@ core.register_node("painting:easel", {
 		ent.fd = fd
 
 		meta:set_int("has_canvas", 1)
-		-- player:get_inventory():set_stack("main", wield_item_idx, ItemStack(""))
 	end,
 
 	can_dig = function(pos)

--- a/painting.lua
+++ b/painting.lua
@@ -447,15 +447,9 @@ core.register_node("painting:canvasnode", {
 					if obj:is_valid() then
 						obj:set_properties{textures = {}}
 						obj:remove()
-						--core.log("action", "[painting] _paintent_uuid succesfully removed")
-					else
-						--core.log("error", "[painting] _paintent_uuid is an invalid object")
+						node_meta:set_string("paintent_uuid", " ")
 					end
-				else
-					--core.log("error", "[paintent] _paintent_uuid object is does no longer exist")
 				end
-			else 
-				--core.log("error", "[paintent] _paintent_uuid is nil")
 			end
 		end
 	end,
@@ -528,9 +522,8 @@ core.register_node("painting:easel", {
 		pos.z = pos.z - 0.01 * dir.z
 
 		local obj = core.add_entity(pos, "painting:paintent")
-		--canvasnode._paintent_obj_uuid = obj:get_luaentity().object:get_guid()
-		canvasnode_meta:set_string("paintent_uuid", obj:get_luaentity().object:get_guid())
-		core.log("action", "paintent uuid:" .. canvasnode_meta:get_string("paintent_uuid"))
+		canvasnode_meta:set_string("paintent_uuid", obj:get_luaentity().object:get_guid()) -- we must store object id in the node meta so that we can later adress the entity and remove it
+		
 		obj:set_properties{ collisionbox = paintbox[fd%2] }
 		obj:set_armor_groups{immortal=1}
 		obj:set_yaw(math.pi * fd / -2)

--- a/painting.lua
+++ b/painting.lua
@@ -235,35 +235,40 @@ core.register_entity("painting:paintent", {
 	},
 
 	on_punch = function(self, puncher)
-		--check for brush.
-		local wielded = puncher:get_wielded_item()
-		local def = wielded:get_definition()
-		if (not def) or (not def._painting_brush) then -- Not one of the brushes; can't paint.
-			return
-		end
-		local color = def._painting_brush.color
-		if not color then
-			local meta = puncher:get_wielded_item():get_meta()
-			color = meta:get("color")
-		end
-		if not color then
-			core.log("warning", "[painting] Brush color not found - "..def.name)
-			return
-		end
-
-		assert(self.object)
-		local x,y = figure_paint_pos(self, puncher)
-		draw_input(self, def._painting_brush, x,y, puncher:get_player_control().sneak)
-		
-		if not core.is_creative_enabled(puncher:get_player_name())
-				and def._painting_brush.wear then
-			wielded:add_wear(def._painting_brush.wear)
-			if wielded:get_count()==0 then
-				if def._painting_brush.break_stack then
-					wielded = ItemStack(def._painting_brush.break_stack)
-				end
+		if puncher:is_player() == true then
+			--check for brush.
+			local wielded = puncher:get_wielded_item()
+			local def = wielded:get_definition()
+			if (not def) or (not def._painting_brush) then -- Not one of the brushes; can't paint.
+				return
 			end
-			puncher:set_wielded_item(wielded)
+			local color = def._painting_brush.color
+			if not color then
+				local meta = puncher:get_wielded_item():get_meta()
+				color = meta:get("color")
+			end
+			if not color then
+				core.log("warning", "[painting] Brush color not found - "..def.name)
+				return
+			end
+
+			assert(self.object)
+			local x,y = figure_paint_pos(self, puncher)
+			draw_input(self, def._painting_brush, x,y, puncher:get_player_control().sneak)
+			
+			if not core.is_creative_enabled(puncher:get_player_name())
+					and def._painting_brush.wear then
+				wielded:add_wear(def._painting_brush.wear)
+				if wielded:get_count()==0 then
+					if def._painting_brush.break_stack then
+						wielded = ItemStack(def._painting_brush.break_stack)
+					end
+				end
+				puncher:set_wielded_item(wielded)
+			end
+		else
+			self.object:set_armor_groups{immortal=0}
+			self.object:set_hp(0)
 		end
 	end,
 
@@ -277,7 +282,7 @@ core.register_entity("painting:paintent", {
 		self.res = data.res
 		self.version = data.version
 		self.grid = data.grid
-		--legacy.fix_grid(self.grid, self.version)
+		legacy.fix_grid(self.grid, self.version)
     self.version = current_version
 		self.object:set_properties{ textures = { painting.to_imagestring(self.grid, self.res) }}
 		if not self.fd then
@@ -286,12 +291,6 @@ core.register_entity("painting:paintent", {
 		self.object:set_properties{ collisionbox = paintbox[self.fd%2] }
 		self.object:set_armor_groups{immortal=1}
 	end,
-
-	-- fix https://github.com/lord-server/lord/issues/2383 
-	--on_detach = function(self, removal)
-	--	self.object:set_properties{textures = {}}
-	--	self.object:remove()
-	--end,
 
 	get_staticdata = function(self)
 		return core.serialize{fd = self.fd, res = self.res,
@@ -402,8 +401,6 @@ core.register_node("painting:canvasnode", {
 		not_in_creative_inventory=1},
 
 	drop = "",
-	
-	_paintent_obj_uuid = nil,
 
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		--get data and remove pixels
@@ -435,23 +432,6 @@ core.register_node("painting:canvasnode", {
 		item_meta:set_string("version", data.version)
 		item_meta:set_string("grid", painting.compress(core.serialize(data.grid)))
 		digger:get_inventory():add_item("main", item)
-	end,
-	
-	on_destruct = function(pos)
-		local node_meta = core.get_meta(pos)
-		if node_meta then
-			local paintent_uuid = node_meta:get_string("paintent_uuid")
-			if paintent_uuid then
-				local obj = core.objects_by_guid[paintent_uuid]
-				if obj then
-					if obj:is_valid() then
-						obj:set_properties{textures = {}}
-						obj:remove()
-						node_meta:set_string("paintent_uuid", " ")
-					end
-				end
-			end
-		end
 	end,
 })
 
@@ -516,14 +496,13 @@ core.register_node("painting:easel", {
 		core.add_node(pos, { name = "painting:canvasnode", param2 = fd})
 		local canvasnode = core.get_node(pos)
 		local canvasnode_meta = core.get_meta(pos)
+		core.log("action", "canvasnode pos: (" .. pos.x .. " / " .. pos.y .. " / " .. pos.z .. ")")
 
 		local dir = dirs[fd]
 		pos.x = pos.x - 0.01 * dir.x
 		pos.z = pos.z - 0.01 * dir.z
 
 		local obj = core.add_entity(pos, "painting:paintent")
-		canvasnode_meta:set_string("paintent_uuid", obj:get_luaentity().object:get_guid()) -- we must store object id in the node meta so that we can later adress the entity and remove it
-		
 		obj:set_properties{ collisionbox = paintbox[fd%2] }
 		obj:set_armor_groups{immortal=1}
 		obj:set_yaw(math.pi * fd / -2)

--- a/painting.lua
+++ b/painting.lua
@@ -496,23 +496,29 @@ core.register_node("painting:easel", {
 			grid = wield_meta:get_string("grid"),
 		}
 		if (data.res>0) and (data.version=="hexcolors") and (data.grid~="") then
+			-- add painting for edit
 			ent.grid = core.deserialize(painting.decompress(data.grid))
 			ent.res = data.res
 			ent.version = data.version
 			obj:set_properties{textures = { painting.to_imagestring(ent.grid, ent.res) }}
-			player:get_inventory():remove_item("main", wield_item:take_item())
+			-- player:get_inventory():remove_item("main", wield_item:take_item())
+			wield_item:take_item()
+			player:set_wielded_item(wield_item)
 		else
+			-- add empty canvas
 			ent.grid = initgrid(def._painting_canvas_resolution)
 			ent.res = def._painting_canvas_resolution
 			ent.version = current_version
 			if not core.is_creative_enabled(player:get_player_name()) then
-				player:get_inventory():remove_item("main", wield_item:take_item())
+				-- player:get_inventory():remove_item("main", wield_item:take_item())
+				wield_item:take_item()
+				player:set_wielded_item(wield_item)
 			end
 		end
 		ent.fd = fd
 
 		meta:set_int("has_canvas", 1)
-		player:get_inventory():set_stack("main", wield_item_idx, ItemStack(""))
+		-- player:get_inventory():set_stack("main", wield_item_idx, ItemStack(""))
 	end,
 
 	can_dig = function(pos)

--- a/painting.lua
+++ b/painting.lua
@@ -477,7 +477,17 @@ core.register_node("painting:easel", {
 			-- this is not likely going to happen
 			return
 		end
+		
+		-- A screwdriver can rotate easel in 3D space.
+		-- Because of this node.param2 can have values not just 0..3 but also 4..7, 8..11, 12..15, 16..19, 20..23.
+		-- Failing to address these values crash the server as pointed out in: https://github.com/lord-server/lord/issues/2380 .
+		-- TODO: Handle 3D coordinates adequately to place canvas right on the easel.
 		local fd = node.param2
+		
+		if fd > 3 then
+			return
+		end
+
 		core.add_node(pos, { name = "painting:canvasnode", param2 = fd})
 
 		local dir = dirs[fd]

--- a/painting.lua
+++ b/painting.lua
@@ -267,7 +267,7 @@ core.register_entity("painting:paintent", {
 				puncher:set_wielded_item(wielded)
 			end
 		else
-			self.object:set_armor_groups{immortal=0}
+			-- nazgul's explosive attacks or other mobs destroy the entity irreversably
 			self.object:set_hp(0)
 		end
 	end,

--- a/painting.lua
+++ b/painting.lua
@@ -277,7 +277,7 @@ core.register_entity("painting:paintent", {
 		self.res = data.res
 		self.version = data.version
 		self.grid = data.grid
-		legacy.fix_grid(self.grid, self.version)
+		--legacy.fix_grid(self.grid, self.version)
     self.version = current_version
 		self.object:set_properties{ textures = { painting.to_imagestring(self.grid, self.res) }}
 		if not self.fd then
@@ -286,6 +286,12 @@ core.register_entity("painting:paintent", {
 		self.object:set_properties{ collisionbox = paintbox[self.fd%2] }
 		self.object:set_armor_groups{immortal=1}
 	end,
+
+	-- fix https://github.com/lord-server/lord/issues/2383 
+	--on_detach = function(self, removal)
+	--	self.object:set_properties{textures = {}}
+	--	self.object:remove()
+	--end,
 
 	get_staticdata = function(self)
 		return core.serialize{fd = self.fd, res = self.res,
@@ -396,6 +402,8 @@ core.register_node("painting:canvasnode", {
 		not_in_creative_inventory=1},
 
 	drop = "",
+	
+	_paintent_obj_uuid = nil,
 
 	after_dig_node = function(pos, oldnode, oldmetadata, digger)
 		--get data and remove pixels
@@ -427,7 +435,30 @@ core.register_node("painting:canvasnode", {
 		item_meta:set_string("version", data.version)
 		item_meta:set_string("grid", painting.compress(core.serialize(data.grid)))
 		digger:get_inventory():add_item("main", item)
-	end
+	end,
+	
+	on_destruct = function(pos)
+		local node_meta = core.get_meta(pos)
+		if node_meta then
+			local paintent_uuid = node_meta:get_string("paintent_uuid")
+			if paintent_uuid then
+				local obj = core.objects_by_guid[paintent_uuid]
+				if obj then
+					if obj:is_valid() then
+						obj:set_properties{textures = {}}
+						obj:remove()
+						--core.log("action", "[painting] _paintent_uuid succesfully removed")
+					else
+						--core.log("error", "[painting] _paintent_uuid is an invalid object")
+					end
+				else
+					--core.log("error", "[paintent] _paintent_uuid object is does no longer exist")
+				end
+			else 
+				--core.log("error", "[paintent] _paintent_uuid is nil")
+			end
+		end
+	end,
 })
 
 local easelbox = { -- Specifies 3d model.
@@ -489,12 +520,17 @@ core.register_node("painting:easel", {
 		end
 
 		core.add_node(pos, { name = "painting:canvasnode", param2 = fd})
+		local canvasnode = core.get_node(pos)
+		local canvasnode_meta = core.get_meta(pos)
 
 		local dir = dirs[fd]
 		pos.x = pos.x - 0.01 * dir.x
 		pos.z = pos.z - 0.01 * dir.z
 
 		local obj = core.add_entity(pos, "painting:paintent")
+		--canvasnode._paintent_obj_uuid = obj:get_luaentity().object:get_guid()
+		canvasnode_meta:set_string("paintent_uuid", obj:get_luaentity().object:get_guid())
+		core.log("action", "paintent uuid:" .. canvasnode_meta:get_string("paintent_uuid"))
 		obj:set_properties{ collisionbox = paintbox[fd%2] }
 		obj:set_armor_groups{immortal=1}
 		obj:set_yaw(math.pi * fd / -2)


### PR DESCRIPTION
Исправление проблемы https://github.com/lord-server/lord/issues/1657 выполнено путём копирования коммита: https://github.com/sfence/painting/commit/caed68246e61b79834161a9d13122d7cb7d141e4

Исправление проблемы https://github.com/lord-server/lord/issues/2380 основано на комментарии https://github.com/lord-server/lord/issues/2380#issuecomment-4769896282 (предложение (б) ). 

Исправление проблемы https://github.com/lord-server/lord/issues/2383 заключается в изменении обработчика `on_punch` сущности `painting:paintent` следующим образом:
1. Выполняется проверка того, кто наносит удар: игрок или нет.
2. Если удар наносит игрок, то обработчик работает без изменений, и происходит рисование на холсте.
3. Если удар наносит не игрок, то здоровье сущности `painting:paintent` устанавливается равным нулю, чтобы механизм движка корректно удалил её после отработки функций `explode_area` и `explode_objects` из фреймворка Voxrame (mods/Voxrame/projectiles/src/projectiles/api.lua), которые вызываются при взрыве шара назгула.

Недостаток этого подхода состоит в том, что в перспективе любой моб, атакующий картину, может уничтожить её с одного удара.
